### PR TITLE
Add DeepSeek runtime and connector infrastructure

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,0 +1,11 @@
+connectors:
+  deepseek:
+    class: connectors.deepseek.DeepSeekConnector
+    credentials:
+      api_key_env: DEEPSEEK_API_KEY
+    model: deepseek-chat
+routing:
+  default: deepseek
+  rules:
+    - match: "generate"
+      connector: deepseek

--- a/scripts/run_host.py
+++ b/scripts/run_host.py
@@ -1,0 +1,51 @@
+"""CLI entry point for running the MCP host runtime."""
+from __future__ import annotations
+
+import argparse
+import importlib
+from pathlib import Path
+
+from mcp_host.runtime import HostRuntime
+
+
+def _build_http_client() -> object | None:
+    try:
+        import requests
+    except ImportError:  # pragma: no cover - requests is optional for tests
+        return None
+
+    class RequestsHTTPClient:
+        def post(self, url: str, json: dict, headers: dict) -> dict:
+            response = requests.post(url, json=json, headers=headers, timeout=30)
+            response.raise_for_status()
+            return response.json()
+
+    return RequestsHTTPClient()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the MCP host runtime.")
+    parser.add_argument(
+        "--config",
+        default=Path("config/settings.yaml"),
+        help="Path to the runtime configuration file.",
+    )
+    args = parser.parse_args()
+
+    runtime = HostRuntime(args.config)
+    http_client = _build_http_client()
+
+    connectors_cfg = runtime.config.get("connectors", {})
+    deepseek_cfg = connectors_cfg.get("deepseek", {})
+
+    module_name, class_name = deepseek_cfg.get("class", "connectors.deepseek.DeepSeekConnector").rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    connector_cls = getattr(module, class_name)
+    connector = connector_cls(deepseek_cfg, http_client=http_client)
+    runtime.register_connector("deepseek", connector)
+
+    runtime.listen()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/connectors/deepseek.py
+++ b/src/connectors/deepseek.py
@@ -1,0 +1,92 @@
+"""DeepSeek connector for MCP host runtime."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional, Protocol
+
+
+class HTTPClient(Protocol):
+    """Protocol for HTTP clients used by the connector."""
+
+    def post(self, url: str, json: Dict[str, Any], headers: Dict[str, str]) -> Any:
+        """Send a POST request."""
+
+
+class AuthenticationError(RuntimeError):
+    """Raised when authentication credentials are missing."""
+
+
+class DeepSeekConnector:
+    """Connector that wraps DeepSeek completion APIs for MCP tasks."""
+
+    def __init__(self, config: Dict[str, Any], http_client: Optional[HTTPClient] = None) -> None:
+        self.config = config or {}
+        self.http_client = http_client
+        self.api_key = self._load_api_key()
+        self.endpoint = self.config.get("endpoint", "https://api.deepseek.com/v1/chat/completions")
+
+    def _load_api_key(self) -> str:
+        credentials = self.config.get("credentials", {})
+        api_key = credentials.get("api_key")
+        env_var = credentials.get("api_key_env")
+
+        if not api_key and env_var:
+            api_key = os.getenv(env_var)
+
+        if not api_key:
+            raise AuthenticationError("DeepSeek API key is not configured.")
+
+        return api_key
+
+    def _build_payload(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        messages = request.get("messages")
+        if not messages:
+            prompt = request.get("prompt") or request.get("task") or ""
+            messages = [{"role": "user", "content": prompt}]
+
+        payload = {
+            "model": self.config.get("model", "deepseek-chat"),
+            "messages": messages,
+            "temperature": request.get("temperature", self.config.get("temperature", 0.7)),
+        }
+        return payload
+
+    def _call_api(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.http_client:
+            raise RuntimeError("No HTTP client configured for DeepSeekConnector.")
+
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = self.http_client.post(self.endpoint, json=payload, headers=headers)
+        return response
+
+    def send_task(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        payload = self._build_payload(request)
+        try:
+            response = self._call_api(payload)
+        except AuthenticationError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - propagate unexpected errors downstream
+            return {
+                "error": str(exc),
+                "retryable": isinstance(exc, (TimeoutError, ConnectionError)),
+            }
+        return response
+
+    def normalize_response(self, response: Dict[str, Any]) -> Dict[str, Any]:
+        if "error" in response:
+            return response
+
+        choices = response.get("choices")
+        if choices:
+            message = choices[0].get("message", {})
+            return {
+                "role": message.get("role", "assistant"),
+                "content": message.get("content", ""),
+                "raw": response,
+            }
+
+        # Fallback to pass-through of unknown structures.
+        return {"raw": response}
+
+
+__all__ = ["DeepSeekConnector", "AuthenticationError"]

--- a/src/mcp_host/runtime.py
+++ b/src/mcp_host/runtime.py
@@ -1,0 +1,94 @@
+"""Runtime management for MCP host applications."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except ImportError:  # pragma: no cover - fallback for environments without PyYAML
+    yaml = None
+
+
+class UnknownConnectorError(RuntimeError):
+    """Raised when a requested connector cannot be resolved."""
+
+
+class HostRuntime:
+    """Manage connectors, global context, and task routing for MCP hosts."""
+
+    def __init__(self, config_path: str | Path) -> None:
+        self.config_path = Path(config_path)
+        self.config: Dict[str, Any] = self._load_config(self.config_path)
+        self.context: Dict[str, Any] = {}
+        self.connectors: Dict[str, Any] = {}
+
+    @staticmethod
+    def _load_config(path: Path) -> Dict[str, Any]:
+        with path.open("r", encoding="utf-8") as handle:
+            raw = handle.read()
+
+        if yaml:
+            data = yaml.safe_load(raw) or {}
+        else:  # Fallback to JSON parsing when PyYAML is unavailable.
+            data = json.loads(raw or "{}")
+        return data
+
+    def register_connector(self, name: str, connector: Any) -> None:
+        self.connectors[name] = connector
+
+    def _resolve_connector_name(self, request: Dict[str, Any]) -> str:
+        if connector_name := request.get("connector"):
+            if connector_name in self.connectors:
+                return connector_name
+            raise UnknownConnectorError(f"Connector '{connector_name}' is not registered.")
+
+        routing = self.config.get("routing", {})
+        rules = routing.get("rules", [])
+        intent = request.get("intent") or request.get("task") or ""
+
+        for rule in rules:
+            match_value = rule.get("match")
+            if match_value and match_value in intent:
+                connector_name = rule["connector"]
+                if connector_name in self.connectors:
+                    return connector_name
+
+        default_connector = routing.get("default")
+        if default_connector and default_connector in self.connectors:
+            return default_connector
+
+        raise UnknownConnectorError("Unable to resolve connector for request.")
+
+    def route_task(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        connector_name = self._resolve_connector_name(request)
+        connector = self.connectors[connector_name]
+        response = connector.send_task(request)
+        normalized = connector.normalize_response(response)
+        return normalized
+
+    def listen(self, stream: Optional[Any] = None) -> None:
+        """Listen for JSON-encoded MCP requests on the provided stream."""
+
+        stream = stream or sys.stdin
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                request = json.loads(line)
+            except json.JSONDecodeError as exc:
+                error = {"error": f"Invalid request payload: {exc}"}
+                print(json.dumps(error), flush=True)
+                continue
+
+            try:
+                response = self.route_task(request)
+            except Exception as exc:  # noqa: BLE001 - propagate runtime errors to the client
+                response = {"error": str(exc)}
+            print(json.dumps(response), flush=True)
+
+
+__all__ = ["HostRuntime", "UnknownConnectorError"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_deepseek_connector.py
+++ b/tests/test_deepseek_connector.py
@@ -1,0 +1,49 @@
+import pytest
+
+from connectors.deepseek import AuthenticationError, DeepSeekConnector
+
+
+class DummyHTTPClient:
+    def __init__(self, response=None, error: Exception | None = None) -> None:
+        self.response = response or {"choices": [{"message": {"role": "assistant", "content": "hi"}}]}
+        self.error = error
+        self.calls = []
+
+    def post(self, url, json, headers):  # noqa: D401 - testing stub
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        if self.error:
+            raise self.error
+        return self.response
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+
+def test_authentication_from_environment(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "secret")
+    connector = DeepSeekConnector(
+        {"credentials": {"api_key_env": "DEEPSEEK_API_KEY"}},
+        http_client=DummyHTTPClient(),
+    )
+    response = connector.send_task({"prompt": "Hello"})
+    normalized = connector.normalize_response(response)
+    assert normalized["content"] == "hi"
+
+
+def test_missing_credentials_raises():
+    with pytest.raises(AuthenticationError):
+        DeepSeekConnector({"credentials": {}}, http_client=DummyHTTPClient())
+
+
+def test_failure_recovery_returns_retryable(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "secret")
+    client = DummyHTTPClient(error=TimeoutError("timeout"))
+    connector = DeepSeekConnector(
+        {"credentials": {"api_key_env": "DEEPSEEK_API_KEY"}},
+        http_client=client,
+    )
+    response = connector.send_task({"prompt": "Hi"})
+    assert response["error"] == "timeout"
+    assert response["retryable"] is True

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_host.runtime import HostRuntime
+
+
+class StubConnector:
+    def __init__(self) -> None:
+        self.requests = []
+
+    def send_task(self, request):
+        self.requests.append(request)
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    @staticmethod
+    def normalize_response(response):
+        message = response["choices"][0]["message"]
+        return {"role": message["role"], "content": message["content"]}
+
+
+@pytest.fixture()
+def runtime(tmp_path: Path) -> HostRuntime:
+    config = {
+        "connectors": {"deepseek": {"class": "connectors.deepseek.DeepSeekConnector"}},
+        "routing": {
+            "default": "deepseek",
+            "rules": [{"match": "generate", "connector": "deepseek"}],
+        },
+    }
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    host_runtime = HostRuntime(config_path)
+    stub = StubConnector()
+    host_runtime.register_connector("deepseek", stub)
+    host_runtime.stub = stub
+    return host_runtime
+
+
+def test_route_task_uses_matching_rule(runtime: HostRuntime):
+    response = runtime.route_task({"intent": "generate summary", "prompt": "Hello"})
+    assert response == {"role": "assistant", "content": "ok"}
+    assert runtime.stub.requests[0]["prompt"] == "Hello"
+
+
+def test_route_task_unknown_connector(runtime: HostRuntime):
+    with pytest.raises(Exception):
+        runtime.route_task({"connector": "missing", "intent": "generate"})


### PR DESCRIPTION
## Summary
- add a host runtime that loads configuration, registers connectors, and routes incoming MCP requests
- implement a DeepSeek connector with authentication, payload formatting, and response normalization
- provide CLI entrypoint, configuration defaults, and tests covering routing, authentication, and failure handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d7e84bf5bc8333b773c859577e13d2